### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: true
+dist: trusty
+language: python
+matrix:
+  include:
+    - python: "3.5"
+before_install:
+  - "sudo apt-get update && sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended latexmk poppler-utils latex-xcolor lmodern texlive-xetex texlive-generic-recommended"
+install:
+  - git clone https://github.com/lsst/lsst-texmf.git
+  - rm images
+  - git clone https://github.com/lsst-dm/images
+script:
+  - export TEXMFHOME=./lsst-texmf/texmf
+  - rm LDM-294.pdf
+  - make

--- a/LDM-294.tex
+++ b/LDM-294.tex
@@ -17,13 +17,10 @@
 
 \begin{document}
 
-\title  {Data Management Organization and Management }
-\setDocTitle[DM PMP] {}
+\title[DM PMP]{Data Management Organization and Management }
 
 \author   {William O'Mullane, Mario Juric, Jeffrey P Kantor,  Tim Axelrod,  Roberta Allsman}                % the author(s) \setDocApprove  {LSST Project Oeefice}              % approval by ...
 \setDocRef      {LDM-294} % the reference code
-\setDocIssue    {2}                        % the issue
-\setDocRevision {2}                        % the revision
 \setDocDate     {\today}              % the date of the issue
 \setDocStatus   {draft}                    % the document status
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,19 @@
 # LDM-294
-DM management plan update in LaTex. 
+DM management plan update in LaTex.
 
-
-
-This is following a lsstdoc.cls. 
-You need the lsst-texmf in your TEXMFLOCAL to build it. 
+This document uses [`lsstdoc.cls`](https://lsst-texmf.lsst.io).
+You need the `lsst-texmf` files in your TEXMFHOME to build it.
 
 Clone this repo:
 
      https://github.com/lsst/lsst-texmf/
 
+then add the `texmf` folder  to TEXMFHOME environment variable in your bashrc or equivalent
 
-then add the texmf folder  to TEXMFLOCAL environment variable in your bashrc or equivalent
+    export TEXMFHOME=path-to-lsst-texmf/texmf
 
-    export TEXMFLOCAL=pathtolsst-texmf/texmf
+For the document to build there must be an images directory cloned from
 
+   https://github.com/lsst-dm/images
 
-then you must run 
-
-    mktexlsr
-
-After this tex will find all the cls files bibliography etc ..
-
-
+located in `../../`.


### PR DESCRIPTION
Add a Travis file to force the document to build to test it.

Complications are:

* We commit the PDF when we should not.
* The `images` soft link points to a random part of the file system and must be replaced with a clone of the images repository.

We should consider using submodules for the images to ensure that the images in the approved version of the document match the images that were approved by CCB.