### PR TITLE
DM-11548: Merge CCB and SE membership

### DIFF
--- a/dmgroups.tex
+++ b/dmgroups.tex
@@ -44,7 +44,7 @@ DM System Science Team communication mechanisms are described on the SST Conflue
 \subsection{DM Systems Engineering Team \label{sect:sysengt}}
 
 The Systems Engineering Team is led by the DMPM (\secref{role:dmpm}) and looks after all aspects of systems engineering.
-It is comprised of not only the Systems Engineer (\secref{role:sysengineer}) but also the Software Architect (\secref{role:softarc}), Operations Architect (\secref{role:opsarc}), Pipeline Scientist (\secref{role:pipe}) and Interface Scientist (\secref{role:dmis}).
+It is comprised of not only the Systems Engineer (\secref{role:sysengineer}), but also the Software Architect (\secref{role:softarc}), Operations Architect (\secref{role:opsarc}), Pipeline Scientist (\secref{role:pipe}), Interface Scientist (\secref{role:dmis}), and the DM Deputy Project Manager (\secref{role:dmdpm}).
 
 While the product owners (\secref{role:prodo}) help DM to create products which are fit for purpose, the Systems Engineering Team must ensure we do it correctly. This group concerns itself with (sub)system wide decisions on architecture and software engineering.
 
@@ -128,8 +128,8 @@ DMCCB validates that the form and content of the Technical Baseline is consisten
 	\end{itemize}
 \item Membership
 	\begin{itemize}
-	\item Chaired by the Systems Engineer
-	\item Members include the DM Software Architect (\S\ref{role:softarc}), DM Operations Architect (\S\ref{role:opsarc}), DM System Interfaces Scientist (\S\ref{role:dmis}), DM SQuaRE T/CAM (\S\ref{role:tcam}), DM Release Manager (\S\ref{role:dmrm}) and DM Project Manager (\S\ref{role:dmpm})
+	\item Chaired by the Systems Engineer (\secref{role:sysengineer}).
+	\item The DMCCB has the same membership as the Systems Engineering Team (\secref{sect:sysengt}).
 	\item For on-line virtual meetings, if a consensus or quorum or is not reached within one week, the DM Project Manager will make a unilateral decision
 	\end{itemize}
 \item Responsibilities

--- a/dmgroups.tex
+++ b/dmgroups.tex
@@ -44,7 +44,7 @@ DM System Science Team communication mechanisms are described on the SST Conflue
 \subsection{DM Systems Engineering Team \label{sect:sysengt}}
 
 The Systems Engineering Team is led by the DMPM (\secref{role:dmpm}) and looks after all aspects of systems engineering.
-It is comprised of not only the Systems Engineer (\secref{role:sysengineer}), but also the Software Architect (\secref{role:softarc}), Operations Architect (\secref{role:opsarc}), Pipeline Scientist (\secref{role:pipe}), Interface Scientist (\secref{role:dmis}), and the DM Deputy Project Manager (\secref{role:dmdpm}).
+It is comprised of not only the Systems Engineer (\secref{role:sysengineer}), but also the Software Architect (\secref{role:softarc}), Operations Architect (\secref{role:opsarc}), DM Subsystem Scientist (\secref{role:dmps}), Pipeline Scientist (\secref{role:pipe}), Interface Scientist (\secref{role:dmis}), and the DM Deputy Project Manager (\secref{role:dmdpm}).
 
 While the product owners (\secref{role:prodo}) help DM to create products which are fit for purpose, the Systems Engineering Team must ensure we do it correctly. This group concerns itself with (sub)system wide decisions on architecture and software engineering.
 


### PR DESCRIPTION
Whilst leaving the entities distinct, now state that CCB and SE teams have the same membership. Org chart also updated.