### PR TITLE
Reorganize makefile to have separate python and latex targets for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,12 @@ install:
    - "pip install -r requirements.txt"
 script:
    # Prepare document dependencies in Travis (Python 3.5) environment
-   - "make wbslist.tex"
-   - "make ProductTree.tex"
+   - "make generated"
    # Ensure acronyms are built
    - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make acronyms'"
    # Compile LaTeX using containerized lsst-texmf.
    # Make targets that rely on Python should be no-ops at this point.
-   - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make all'"
+   - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make travis-all'"
    # Deploy website. See https://github.com/lsst-sqre/lander for CLI options
    - "lander --pdf LDM-294.pdf --upload --lsstdoc LDM-294.tex --env=travis --ltd-product ldm-294 --extra-downloads ProductTree.pdf ProductTreeLand.pdf"
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 export TEXMFHOME = lsst-texmf/texmf
 
-TEX=DDMP.tex	dmgroups.tex	dmroles.tex	leadtutes.tex	probman.tex LDM-294.tex	devprocess.tex	dmorg.tex	dmwbs.tex dmarc.tex	dmproducts.tex	intro.tex  
+TEX=DDMP.tex	dmgroups.tex	dmroles.tex	leadtutes.tex	probman.tex LDM-294.tex	devprocess.tex	dmorg.tex	dmwbs.tex dmarc.tex	dmproducts.tex	intro.tex
+
+MKPDF=latexmk -pdf
+
+GENERATED_FIGURES=ProductTreeLand.pdf ProductTree.pdf
+GENERATED_FIGURES_TEX=$(GENERATED_FIGURES:.pdf=.tex)
 
 all : LDM-294.pdf
 
-LDM-294.pdf: *.tex wbslist.tex ProductTree.pdf ProductTreeLand.pdf
-	latexmk -bibtex -pdf -f LDM-294.tex
+LDM-294.pdf: *.tex wbslist.tex ${GENERATED_FIGURES}
+	$(MKPDF) -bibtex -f LDM-294.tex
 
-acronyms:${TEX} myacronyms.tex
+acronyms: ${TEX} myacronyms.tex
 	acronyms.csh  ${TEX}
 
 wbslist.tex: wbs/*tex productlist.csv
@@ -18,10 +23,20 @@ ProductTree.tex: productlist.csv
 	python makeProductTree.py --depth=2
 
 ProductTree.pdf: ProductTree.tex
-	latexmk -pdf ProductTree.tex
+	$(MKPDF) $<
 
 ProductTreeLand.tex: productlist.csv
 	python makeProductTree.py --land=1
 
 ProductTreeLand.pdf: ProductTreeLand.tex
-	latexmk -pdf ProductTreeLand.tex
+	$(MKPDF) $<
+
+# These targets are designed to be used by Travis
+# so that we can control when python will be called.
+# "generated" can call python.
+generated: $(GENERATED_FIGURES_TEX) wbslist.tex
+
+# "travis-all" must only call Latex
+travis-all: *.tex
+	for f in $(GENERATED_FIGURES_TEX); do $(MKPDF) "$$f" ; done
+	$(MKPDF) -bibtex -f LDM-294


### PR DESCRIPTION
I had done this fix to separate things out but whilst editing the travis file I realized that the real problem is that there are three generated files but the travis system was only pre-building two of them. It's also a bit weird that the PR one works and the push one failed in #53. Why didn't they both need to rebuild `ProductTreeLand.tex`? Then I realized that `ProductTreeLand.tex` is still in the repo so it might be possible for the makefile to decide that it doesn't need to rebuild it. `ProductTreeLand.tex` is not used by LDM-294.tex though so I'm not sure why we build it at all.

The real fix may be to ignore all the Makefile cleanups on this PR and simply remove `ProductTreeLand.tex` from the build system.